### PR TITLE
chapter: use 'html' in place of 'cgi' for Python >= 3.8

### DIFF
--- a/pypub/chapter.py
+++ b/pypub/chapter.py
@@ -1,4 +1,8 @@
-import cgi
+try:
+    from cgi import escape
+    import cgi
+except ImportError:
+    import html
 import codecs
 import imghdr
 import os
@@ -143,7 +147,10 @@ class Chapter(object):
         self.content = content
         self._content_tree = BeautifulSoup(self.content, 'html.parser')
         self.url = url
-        self.html_title = cgi.escape(self.title, quote=True)
+        try:
+            self.html_title = cgi.escape(self.title, quote=True)
+        except NameError:
+            self.html_title = html.escape(self.title, quote=True)
 
     def write(self, file_name):
         """


### PR DESCRIPTION
As discussed on
https://github.com/cython/cython/issues/3309
the function 'cgi.escape' was removed from Python 3.8.
'html.escape' should be used instead.

Signed-off-by: Jimmy Durand Wesolowski <jimmy.durand.wesolowski@gmail.com>